### PR TITLE
[feat] 공용컴포넌트 Badge, FeedCard 레이아웃 추가.

### DIFF
--- a/main/src/components/Badge.jsx
+++ b/main/src/components/Badge.jsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components'
+
+const StyledDiv = styled.div`
+  color: ${(props) =>
+    props.isAnswered ? 'var(--brown40)' : 'var(--grayScale40)'};
+  border-color: ${(props) =>
+    props.isAnswered ? 'var(--brown40)' : 'var(--grayScale40)'};
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  line-height: 1rem;
+  padding: 4px 12px;
+`
+
+function Badge({ isAnswered = false }) {
+  return (
+    <StyledDiv isAnswered={isAnswered}>
+      {isAnswered ? '답변 완료' : '미답변'}
+    </StyledDiv>
+  )
+}
+
+export default Badge

--- a/main/src/components/FeedCard.jsx
+++ b/main/src/components/FeedCard.jsx
@@ -1,0 +1,76 @@
+import { useState, useRef } from 'react'
+import styled from 'styled-components'
+import FeedCardQuestion from './FeedCardQuestion'
+import FeedCardAnswer from './FeedCardAnswer'
+import kebabImg from '/public/icons/more.svg'
+import Badge from './Badge'
+
+const StyledDiv = styled.div`
+  padding: 1.5rem;
+  max-width: 684px;
+  margin: 0 auto;
+  border-radius: 1rem;
+  box-shadow: 0 4px 4px var(--grayScale40); //임시값임. shadow 2pt 적용해야함.
+`
+
+const StyledMenubar = styled.div`
+  display: flex;
+  justify-content: space-between;
+`
+const StyledReactionLine = styled.div`
+  hr: {
+    border: none;
+    height: 2px;
+    background-color: #333;
+    margin: 1.25rem;
+  }
+`
+const StyledKebabButton = styled.button`
+  background: url(${kebabImg}) no-repeat center;
+  background-size: contain;
+  width: 24px;
+  height: 24px;
+`
+const Margin = styled.div`
+  height: 2rem;
+`
+
+function FeedCardLayout() {
+  const [isAnswered, setIsAnswerd] = useState(true)
+  const [isKebabOpen, setIsKebabOpen] = useState(false)
+
+  const handleKebabToggle = () => {
+    setIsKebabOpen((prevValue) => !prevValue)
+  }
+  const optionsRef = useRef(null)
+
+  const handleKebabClose = (e) => {
+    if (!optionsRef.current || !optionsRef.current.contains(e.relatedTarget)) {
+      setIsKebabOpen(false)
+    }
+  }
+
+  return (
+    <StyledDiv>
+      <StyledMenubar>
+        <Badge isAnswered={isAnswered} />
+        <StyledKebabButton
+          onClick={handleKebabToggle}
+          onBlur={handleKebabClose}
+        />
+        {isKebabOpen && <Dropdown />}
+      </StyledMenubar>
+      <Margin />
+      <FeedCardQuestion />
+      <Margin />
+      <FeedCardAnswer />
+      <Margin />
+      <StyledReactionLine>
+        <hr />
+        <div>좋아요 싫어요</div>
+      </StyledReactionLine>
+    </StyledDiv>
+  )
+}
+
+export default FeedCardLayout

--- a/main/src/components/FeedCardAnswer.jsx
+++ b/main/src/components/FeedCardAnswer.jsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import temporaryProfile from '/public/images/temporaryProfile.png'
+
+const StyledAnswer = styled.div`
+  display: flex;
+  flex-flow: row;
+`
+const StyledProfile = styled.img`
+  width: 2rem;
+  height: 2rem;
+  margin-right: 0.5rem;
+`
+const StyledUserName = styled.div`
+  font-size: 0.875rem;
+`
+const StyledDate = styled.span`
+  color: var(--grayScale40);
+  margin-left: 0.5rem;
+  font-size: 0.875rem;
+`
+function FeedCardAnswer() {
+  const [answerState, setAnswerState] = useState({})
+  const [modifyState, setModifyState] = useState(false)
+  const [rejectState, setRejectState] = useState(false)
+  //미답변, 답변 작성 중, 답변 수정 중, 답변 완료, 답변 거절 5가지 케이스의 구현 필요
+
+  return (
+    <StyledAnswer>
+      <StyledProfile src={temporaryProfile} />
+      <div>
+        <StyledUserName>
+          아초는 고양이<StyledDate>2주전</StyledDate>
+        </StyledUserName>
+
+        <div>
+          (임시로 넣은 내용임. state 에따라 이부분이 변경되는 기능 구현 필요.)
+          그들을 불러 귀는 이상의 오직 피고, 가슴이 이상, 못할 봄바람이다.
+          찾아다녀도, 전인 방황하였으며, 대한 바이며, 이것이야말로 가치를 청춘의
+          따뜻한 그리하였는가? 몸이 열락의 청춘의 때문이다. 천고에 피어나는 간에
+          밝은 이상, 인생의 만물은 피다. 대중을 이성은 방황하여도, 그리하였는가?
+          크고 평화스러운 품에 방황하였으며, 말이다. 이상은 들어 예수는 크고
+          긴지라 역사를 피다. 얼음에 있음으로써 꽃 보배를 곧 가는 교향악이다.
+          우는 새 예가 우리의 것은 피다. 피가 그것을 어디 앞이 기쁘며, 이상의
+          열락의 위하여서 끝까지 것이다. 있는 봄바람을 방황하여도, 우리의 것은
+          작고 아니한 영원히 듣기만 운다.
+        </div>
+      </div>
+    </StyledAnswer>
+  )
+}
+export default FeedCardAnswer

--- a/main/src/components/FeedCardQuestion.jsx
+++ b/main/src/components/FeedCardQuestion.jsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components'
+
+const StyledTime = styled.div`
+  color: var(--grayScale40);
+  font-size: 14px;
+`
+const StyledTitle = styled.div`
+  color: var(--grayScale60);
+  font-size: 1rem;
+`
+function FeedCardQuestion() {
+  return (
+    <>
+      <StyledTime>질문 · 2주전</StyledTime>
+      <StyledTitle> 좋아하는 동물은?</StyledTitle>
+    </>
+  )
+}
+
+export default FeedCardQuestion

--- a/main/src/components/InputTextArea.jsx
+++ b/main/src/components/InputTextArea.jsx
@@ -1,9 +1,12 @@
 import styled from 'styled-components'
 import media, { size } from '../utils/media'
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+`
 
 const TextArea = styled.textarea`
-  width: 12.6rem;
-  height: 11.6rem;
+  width: 100%;
   background-color: var(--grayScale20);
   resize: none;
   border-radius: 8px;
@@ -15,17 +18,13 @@ const TextArea = styled.textarea`
   &:focus {
     outline: 2px solid var(--brown40); /* 테두리 색상 변경 */
   }
-
-  ${media(size.tablet)`
-    width: 34rem;
-  `}
-
-  ${media(size.desktop)`
-    width: 35rem;
-  `}
 `
-function InputTextArea() {
-  return <TextArea placeholder="답변을 입력해주세요"></TextArea>
+function InputTextArea({ placeholder = 'placeholder를 prop으로 내려주세요' }) {
+  return (
+    <Container>
+      <TextArea placeholder={placeholder}></TextArea>
+    </Container>
+  )
 }
 
 export default InputTextArea


### PR DESCRIPTION
- Badge 컴포넌트
isAnswered prop(boolean값)을 받아서 답변과 미답변시의 디자인 변경 가능.

- FeedCard 컴포넌트
FeedCard에 대한 레이아웃을 맡는 컴포넌트.
케밥버튼 클릭시 메뉴 열림 상태 관련 기능 구현 완료. 케밥메뉴창은 해당 컴포넌트 추가 해야함.
좋아요, 싫어요 버튼 해당 컴포넌트로 변경해야함.

- FeedCardAnswer 컴포넌트
질문에 대한 답변의 내용이 담기는 컴포넌트.
미답변, 답변 작성 중, 답변 수정 중, 답변 완료, 답변 거절 5가지 케이스의 구현 필요.

- FeedCardQuestion 컴포넌트
질문 제목과 작성시간이 표시되는 줄.
시간 기능은 아직 미구현상태.


전체적으로 api에서 데이터를 가져오는 부분 추가 필요.


