### PR TITLE
[feat] 모달 page 레이아웃 및 일부 기능 구현

### DIFF
--- a/main/src/pages/modal/Modal.jsx
+++ b/main/src/pages/modal/Modal.jsx
@@ -32,7 +32,6 @@ const ModalBox = styled.div`
   ${media(size.tablet)`
     width: 38.25rem;
     height: 28.375rem;
-    margin-bottom: 2rem;
   `}
 `
 const Margin = styled.div`
@@ -50,7 +49,7 @@ function Modal({ onClose }) {
         <Margin />
         <InputTextForm
           placeholder={'질문을 입력해주세요'}
-          buttonText="답변 완료"
+          buttonText="질문 보내기"
         />
       </ModalBox>
     </ModalPage>

--- a/main/src/pages/modal/Modal.jsx
+++ b/main/src/pages/modal/Modal.jsx
@@ -1,0 +1,59 @@
+import styled from 'styled-components'
+import ModalFirstLine from './components/ModalFirstLine'
+import ModalSecondLine from './components/ModalSecondLine'
+import InputTextForm from '../../components/InputTextForm'
+import media, { size } from '/src/utils/media'
+const ModalPage = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`
+const ModalBackground = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+`
+const ModalBox = styled.div`
+  background-color: white;
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  width: 90%;
+  height: 70%;
+  padding: 1.35rem 1.5rem;
+  border-radius: 24px;
+
+  ${media(size.tablet)`
+    width: 38.25rem;
+    height: 28.375rem;
+    margin-bottom: 2rem;
+  `}
+`
+const Margin = styled.div`
+  height: 1.5rem;
+`
+
+function Modal({ onClose }) {
+  return (
+    <ModalPage>
+      <ModalBackground onClick={onClose}></ModalBackground>
+      <ModalBox onClick={(e) => e.stopPropagation()}>
+        <ModalFirstLine onClose={onClose} />
+        <Margin />
+        <ModalSecondLine />
+        <Margin />
+        <InputTextForm
+          placeholder={'질문을 입력해주세요'}
+          buttonText="답변 완료"
+        />
+      </ModalBox>
+    </ModalPage>
+  )
+}
+export default Modal

--- a/main/src/pages/modal/components/ModalFirstLine.jsx
+++ b/main/src/pages/modal/components/ModalFirstLine.jsx
@@ -1,0 +1,39 @@
+import close from '/icons/close.svg'
+import messages from '/icons/messages.svg'
+import styled from 'styled-components'
+import media, { size } from '/src/utils/media'
+
+const StyledDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+const StyledTitle = styled.div`
+  flex-grow: 1;
+  font-size: 1.4rem;
+
+  ${media(330)` // 글씨 겹침 문제 해결용.
+    font-size: 1.5rem;
+  `}
+`
+const CloseButton = styled.button`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background-image: url(${close});
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 28px;
+  height: 28px;
+`
+
+function ModalFirstline({ onClose }) {
+  return (
+    <StyledDiv>
+      <img src={messages} />
+      <StyledTitle>질문을 작성하세요</StyledTitle>
+      <CloseButton className={'closeButton'} onClick={onClose}></CloseButton>
+    </StyledDiv>
+  )
+}
+export default ModalFirstline

--- a/main/src/pages/modal/components/ModalSecondLine.jsx
+++ b/main/src/pages/modal/components/ModalSecondLine.jsx
@@ -15,7 +15,7 @@ const StyledImg = styled.img`
 function ModalSecondline() {
   return (
     <StyledDiv>
-      to.
+      To.
       <StyledImg src={temporaryProfile} /> 아초는고양이
     </StyledDiv>
   )

--- a/main/src/pages/modal/components/ModalSecondLine.jsx
+++ b/main/src/pages/modal/components/ModalSecondLine.jsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components'
+import temporaryProfile from '/images/temporaryProfile.png'
+
+const StyledDiv = styled.div`
+  display: flex;
+  justify-content: left;
+  align-items: center;
+`
+const StyledImg = styled.img`
+  width: 1.8rem;
+  height: 1.8rem;
+  margin: 0 0.2rem;
+`
+
+function ModalSecondline() {
+  return (
+    <StyledDiv>
+      to.
+      <StyledImg src={temporaryProfile} /> 아초는고양이
+    </StyledDiv>
+  )
+}
+export default ModalSecondline


### PR DESCRIPTION
![modal_tablet](https://github.com/2team-project/OpenMind/assets/159979425/720f9148-ab5d-4175-99a3-d0cc2ab9178a)
![modal_mobileWindow](https://github.com/2team-project/OpenMind/assets/159979425/7eabd9e4-2fae-4734-9e09-005ff71eaf4a)


- Modal 페이지 및 하위 2개 컴포넌트 추가. 레이아웃 구성 완료, 창 열고 닫는 기능 구현.
- 모바일 /태블릿 이상으로 창 크기가 구분됩니다. 해당 디자인은 Figma에서 참조했습니다.
- 창을 표시할 때는 {state&&<Modal/> }처럼 사용합니다. state명은 isModalOpen 혹은 어떤 버튼의 동작인지 등이 들어가면 좋겠습니다.
- onClose prop을 전달받습니다. 창을 열고 닫는 동작시에 필요합니다. 
모달 창 부분이 아닌 회색 배경을 클릭시와 모달창 내의 X버튼을 눌러 onClose 콜백을 실행해 창을 닫습니다.

아래는 예시 코드입니다.
![image](https://github.com/2team-project/OpenMind/assets/159979425/6a5e6e0c-503a-4a22-a874-899d567ce67d)


- 수정 필요한 사항
ModalSecondLine 컴포넌트는 현재 임시 프로필이미지를 사용 중입니다. 해당 api 관련부분 찾아보고 추후에 개발하겠습니다.
input 내용에 대한 버튼 동작은 현재 구현되지 않았습니다. 신속히 추가하겠습니다.

