### PR TITLE
[feat]FeedCard 조건부렌더링 추가. InputTextForm 버튼동작 구현. FeedCard에 적용.

### DIFF
--- a/main/src/components/FeedCard.jsx
+++ b/main/src/components/FeedCard.jsx
@@ -48,7 +48,7 @@ function FeedCard({ subject, question }) {
   const location = useLocation()
   const pathname = location.pathname
   const postId = pathname.split('/post/')[1]
-  const isKebabButtonNeeded =
+  const isAnswerPage =
     pathname.startsWith('/post/') && postId && postId.includes('/answer')
 
   const handleKebabToggle = () => {
@@ -66,19 +66,35 @@ function FeedCard({ subject, question }) {
   return (
     <StyledDiv>
       <StyledMenubar>
+        {/* 답변상태를 표시합니다. */}
         <Badge isAnswered={isAnswered} />
-        {isKebabButtonNeeded && (
+
+        {/* 케밥버튼은 AnswerPage에서만 렌더링됩니다. */}
+        {isAnswerPage && (
           <StyledKebabButton
             onClick={handleKebabToggle}
             onBlur={handleKebabClose}
           />
         )}
+        {/* Dropdown 현재 미구현입니다. 여기에서 버튼들의 동작 콜백들 prop으로 내리고 editing상태를 FeedCardAnswer에 업데이트해야합니다. */}
         {isKebabOpen && <Dropdown />}
       </StyledMenubar>
       <Margin />
+
+      {/* 질문 내용과 작성 시간이 표시됩니다. */}
       <FeedCardQuestion question={question} />
       <Margin />
-      <FeedCardAnswer subject={subject} answer={answer} question={question} />
+
+      {/* 답변 내용이 표시됩니다. */}
+      <FeedCardAnswer
+        isAnswerPage={isAnswerPage}
+        subject={subject}
+        question={question}
+        editing={false}
+      />
+      <Margin />
+
+      {/* 좋아요와 싫어요 버튼이 표시됩니다. */}
       <StyledReactionLine>
         <ReactionLike />
         <ReactionHate />

--- a/main/src/components/FeedCard.jsx
+++ b/main/src/components/FeedCard.jsx
@@ -91,6 +91,7 @@ function FeedCard({ subject, question }) {
         subject={subject}
         question={question}
         editing={false}
+        // editing값은 state화 해서 사용해야합니다. 케밥버튼 기능 추가시 변경하겠습니다.
       />
       <Margin />
 

--- a/main/src/components/FeedCardAnswer.jsx
+++ b/main/src/components/FeedCardAnswer.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import InputTextForm from './InputTextForm'
 import getElapsedTime from '../utils/getElapsedTime'
 import media, { size } from '../utils/media'
+import { createAnswer, updateAnswer } from '../utils/apiUtils'
 
 const StyledAnswer = styled.div`
   display: flex;
@@ -41,6 +42,8 @@ const RejectDiv = styled.div`
   color: var(--red50);
 `
 
+//여러 상태에서 공통적으로 나오는 subject의 프로필이미지, 이름, 답변생성시간을 표시하는 컴포넌트입니다.
+//답변 생성시간은 답변이 작성된 시간이며, 답변이 없을 경우 보이지 않습니다.
 function SubjectProfile({
   subject,
   showCreatedTime,
@@ -65,14 +68,14 @@ function SubjectProfile({
   )
 }
 
-// isAnswerPage : 현재 페이지가 AnswerPage인지를 받습니다. AnswerPage에서만 prop으로 내리면 됩니다.
 // subject : 답변자 객체를 받습니다. 프로필 이미지, 이름 등을 표시하는데 쓰입니다.
 // question : 질문 하나를 받습니다. 질문 목록 배열에서 map 메서드로 하나만 전달해주세요.
+// isAnswerPage : 현재 페이지가 AnswerPage인지를 받습니다. AnswerPage에서만 prop으로 내리면 됩니다.
 // editing : 현재의 FeedCard가 수정 중인지를 받습니다. AnswerPage에서만 prop으로 내리면 됩니다.
 function FeedCardAnswer({
-  isAnswerPage = false,
   subject,
   question,
+  isAnswerPage = false,
   editing = false,
 }) {
   const [answerContent, setAnswerContent] = useState(null)
@@ -87,13 +90,21 @@ function FeedCardAnswer({
     setAnswer(question.answer ?? null)
     setIsAnswered(answer !== null)
     if (isAnswered) {
-      setIsRejected(answer.isRejected)
+      setIsRejected(answer?.isRejected)
       setAnswerCreatedTime(question?.answer?.createdAt)
     }
-  }, [isAnswered, answer?.isRejected, question?.answer?.createdAt])
+  }, [isAnswered, answer?.isRejected])
 
-  const editButtonOnClick = () => {}
-  const answerButtonOnClick = () => {}
+  //수정하기 버튼 동작
+  const editButtonOnClick = async (content) => {
+    console.log(content)
+    await updateAnswer(question.id, content, isRejected)
+  }
+  //답변하기 버튼 동작
+  const answerButtonOnClick = async (content) => {
+    console.log(content)
+    await createAnswer(question.id, content, isRejected)
+  }
 
   // 답변을 한 경우
   // 답변을 수정중일 경우 인풋 창을 보여주고 수정 중인 버튼이 보입니다.
@@ -110,8 +121,8 @@ function FeedCardAnswer({
               placeholder="답변을 입력해주세요"
               buttonText="수정 완료"
               value={answerContent}
-              onChange={(e) => setAnswerContent(e.target.value)}
-              action={() => editButtonOnClick}
+              onSubmit={(e) => setAnswerContent(e.target.value)}
+              action={editButtonOnClick}
             />
           </SubjectProfile>
         </StyledAnswer>
@@ -157,9 +168,9 @@ function FeedCardAnswer({
             <InputTextForm
               placeholder="답변을 입력해주세요"
               buttonText="답변 완료"
-              value={answerContent}
-              onChange={(e) => setAnswerContent(e.target.value)}
-              action={() => answerButtonOnClick}
+              onSubmit={(text) => {
+                answerButtonOnClick(text)
+              }}
             />
           </SubjectProfile>
         </StyledAnswer>

--- a/main/src/components/FeedCardAnswer.jsx
+++ b/main/src/components/FeedCardAnswer.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import InputTextForm from './InputTextForm'
 import getElapsedTime from '../utils/getElapsedTime'
@@ -6,9 +6,6 @@ import getElapsedTime from '../utils/getElapsedTime'
 const StyledAnswer = styled.div`
   display: flex;
   flex-flow: row;
-`
-const StyledSubject = styled(FeedCardAnswer)`
-  display: flex;
 `
 const StyledProfile = styled.img`
   width: 2rem;
@@ -43,39 +40,81 @@ function SubjectProfile({ answer, subject }) {
   )
 }
 
-// 미답변, 답변 작성 중, 답변 수정 중, 답변 완료, 답변 거절 5가지 케이스의 구현 필요
-function FeedCardAnswer({ subject, answer, question }) {
+// isAnswerPage : 현재 페이지가 AnswerPage인지를 받습니다. AnswerPage에서만 prop으로 내리면 됩니다.
+// subject : 답변자 객체를 받습니다. 프로필 이미지, 이름 등을 표시하는데 쓰입니다.
+// question : 질문 하나를 받습니다. 질문 목록 배열에서 map 메서드로 하나만 전달해주세요.
+// editing : 현재의 FeedCard가 수정 중인지를 받습니다. AnswerPage에서만 prop으로 내리면 됩니다.
+function FeedCardAnswer({
+  isAnswerPage = false,
+  subject,
+  question,
+  editing = false,
+}) {
   const [answerContent, setAnswerContent] = useState(null)
-  const isAnswered = question.answer !== null
-  let isRejected = false
-  if (isAnswered) {
-    isRejected = answer.isRejected
-  }
+  const [isRejected, setIsRejected] = useState(false)
+  const [isAnswered, setIsAnswered] = useState(false)
+  const [answer, setAnswer] = useState(null)
 
-  if (isRejected) {
+  useEffect(() => {
+    setAnswer(question.answer ?? null)
+    setIsAnswered(answer !== null)
+    if (isAnswered) {
+      setIsRejected(answer.isRejected)
+    }
+  }, [isAnswered, answer?.isRejected])
+
+  // 답변을 한 경우
+  // 답변을 수정중일 경우 인풋 창을 보여주고 수정 중인 버튼이 보입니다.
+  if (isAnswered) {
+    if (editing) {
+      return (
+        <>
+          <SubjectProfile subject={subject} answer={answer} />
+          <InputTextForm
+            placeholder="답변을 입력해주세요"
+            buttonText="수정 완료"
+            value={answerContent}
+            onChange={(e) => setAnswerContent(e.target.value)}
+          />
+        </>
+      )
+    }
+    //답변 거절일 경우 인풋 창이나 답변 내용을 보여주지 않습니다.
+    if (isRejected) {
+      return (
+        <>
+          <SubjectProfile subject={subject} answer={answer} />
+          <RejectDiv>답변 거절</RejectDiv>
+        </>
+      )
+    }
+    //그 외의 답변 완료일 경우 답변 내용을 보여줍니다.
     return (
       <>
         <SubjectProfile subject={subject} answer={answer} />
-        <RejectDiv>답변 거절</RejectDiv>
+        {answer?.content}
       </>
     )
   } else {
-    return (
-      <StyledAnswer>
-        <SubjectProfile subject={subject} answer={answer} />
-        <div>
-          {isAnswered ? (
-            <div>{answerContent}</div>
-          ) : (
+    // 답변을 아직 하지 않은 경우
+    // 답변자의 정보와 'post/{id}/answer'페이지는 인풋 폼을 보여줍니다.
+    if (isAnswerPage) {
+      return (
+        <StyledAnswer>
+          <SubjectProfile subject={subject} answer={answer} />
+          <div>
             <InputTextForm
               placeholder="답변을 입력해주세요"
+              buttonText="답변 완료"
               value={answerContent}
               onChange={(e) => setAnswerContent(e.target.value)}
             />
-          )}
-        </div>
-      </StyledAnswer>
-    )
+          </div>
+        </StyledAnswer>
+      )
+    }
+    // 답변을 하지 않았고, answer페이지가 아니라면 아무것도 보여주지 않습니다.
+    return <></>
   }
 }
 export default FeedCardAnswer

--- a/main/src/components/FeedCardAnswer.jsx
+++ b/main/src/components/FeedCardAnswer.jsx
@@ -2,40 +2,65 @@ import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import InputTextForm from './InputTextForm'
 import getElapsedTime from '../utils/getElapsedTime'
+import media, { size } from '../utils/media'
 
 const StyledAnswer = styled.div`
   display: flex;
   flex-flow: row;
 `
 const StyledProfile = styled.img`
+  display: flex;
+  flex-flow: row;
   width: 2rem;
   height: 2rem;
   margin-right: 0.5rem;
+  border-radius: 999px;
+  ${media(size.tablet)`
+   width: 3rem;
+   height: 3rem; `}
+`
+const StyledDiv = styled.div`
+  display: flex;
+  flex-flow: column;
+  flex-grow: 1;
+  gap: 0.5rem;
 `
 const StyledUserName = styled.div`
-  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+  ${media(size.tablet)`
+    font-size: 1.5rem; `}
 `
 const StyledDate = styled.span`
   color: var(--grayScale40);
   margin-left: 0.5rem;
-  font-size: 0.875rem;
+  font-size: 1rem;
 `
 const RejectDiv = styled.div`
   color: var(--red50);
 `
 
-function SubjectProfile({ answer, subject }) {
+function SubjectProfile({
+  subject,
+  showCreatedTime,
+  answerCreatedTime,
+  children,
+}) {
   return (
     <>
       <StyledProfile
         src={subject ? subject.imageSource : '/path/to/default/image.jpg'}
       />
-      <StyledUserName>
-        {subject ? subject.name : 'No Name Provided'}
-        <StyledDate>
-          {subject ? getElapsedTime(subject.createdAt) : '2주전'}
-        </StyledDate>
-      </StyledUserName>
+      <StyledDiv>
+        <StyledUserName>
+          {subject ? subject.name : 'No Name Provided'}
+          <StyledDate>
+            {showCreatedTime ? getElapsedTime(answerCreatedTime) : ''}
+          </StyledDate>
+        </StyledUserName>
+        {children}
+      </StyledDiv>
     </>
   )
 }
@@ -54,46 +79,69 @@ function FeedCardAnswer({
   const [isRejected, setIsRejected] = useState(false)
   const [isAnswered, setIsAnswered] = useState(false)
   const [answer, setAnswer] = useState(null)
+  const [answerCreatedTime, setAnswerCreatedTime] = useState('')
+
+  const showCreatedTime = !editing || !isAnswered
 
   useEffect(() => {
     setAnswer(question.answer ?? null)
     setIsAnswered(answer !== null)
     if (isAnswered) {
       setIsRejected(answer.isRejected)
+      setAnswerCreatedTime(question?.answer?.createdAt)
     }
-  }, [isAnswered, answer?.isRejected])
+  }, [isAnswered, answer?.isRejected, question?.answer?.createdAt])
+
+  const editButtonOnClick = () => {}
+  const answerButtonOnClick = () => {}
 
   // 답변을 한 경우
   // 답변을 수정중일 경우 인풋 창을 보여주고 수정 중인 버튼이 보입니다.
   if (isAnswered) {
     if (editing) {
       return (
-        <>
-          <SubjectProfile subject={subject} answer={answer} />
-          <InputTextForm
-            placeholder="답변을 입력해주세요"
-            buttonText="수정 완료"
-            value={answerContent}
-            onChange={(e) => setAnswerContent(e.target.value)}
-          />
-        </>
+        <StyledAnswer>
+          <SubjectProfile
+            subject={subject}
+            showCreatedTime={showCreatedTime}
+            answerCreatedTime={answerCreatedTime}
+          >
+            <InputTextForm
+              placeholder="답변을 입력해주세요"
+              buttonText="수정 완료"
+              value={answerContent}
+              onChange={(e) => setAnswerContent(e.target.value)}
+              action={() => editButtonOnClick}
+            />
+          </SubjectProfile>
+        </StyledAnswer>
       )
     }
     //답변 거절일 경우 인풋 창이나 답변 내용을 보여주지 않습니다.
     if (isRejected) {
       return (
-        <>
-          <SubjectProfile subject={subject} answer={answer} />
-          <RejectDiv>답변 거절</RejectDiv>
-        </>
+        <StyledAnswer>
+          <SubjectProfile
+            subject={subject}
+            showCreatedTime={showCreatedTime}
+            answerCreatedTime={answerCreatedTime}
+          >
+            <RejectDiv>답변 거절</RejectDiv>
+          </SubjectProfile>
+        </StyledAnswer>
       )
     }
     //그 외의 답변 완료일 경우 답변 내용을 보여줍니다.
     return (
-      <>
-        <SubjectProfile subject={subject} answer={answer} />
-        {answer?.content}
-      </>
+      <StyledAnswer>
+        <SubjectProfile
+          subject={subject}
+          showCreatedTime={showCreatedTime}
+          answerCreatedTime={answerCreatedTime}
+        >
+          {answer?.content}
+        </SubjectProfile>
+      </StyledAnswer>
     )
   } else {
     // 답변을 아직 하지 않은 경우
@@ -101,15 +149,19 @@ function FeedCardAnswer({
     if (isAnswerPage) {
       return (
         <StyledAnswer>
-          <SubjectProfile subject={subject} answer={answer} />
-          <div>
+          <SubjectProfile
+            subject={subject}
+            showCreatedTime={showCreatedTime}
+            answerCreatedTime={answerCreatedTime}
+          >
             <InputTextForm
               placeholder="답변을 입력해주세요"
               buttonText="답변 완료"
               value={answerContent}
               onChange={(e) => setAnswerContent(e.target.value)}
+              action={() => answerButtonOnClick}
             />
-          </div>
+          </SubjectProfile>
         </StyledAnswer>
       )
     }

--- a/main/src/components/InputTextForm.jsx
+++ b/main/src/components/InputTextForm.jsx
@@ -35,11 +35,11 @@ const SendButton = styled.button`
 
 //placeholder에 input의 입력 전 기본값,
 //buttonText는 버튼에 들어갈 문구.
-//action에 버튼 클릭시 동작 콜백
+//onSubmit은 text를 받아서 부모요소에서 실행될 함수
 function InputTextForm({
   placeholder = '질문을 입력해주세요',
   buttonText = '답변 완료',
-  action = () => console.log('action을 추가해주세요'),
+  onSubmit,
 }) {
   const [text, setText] = useState('')
 
@@ -50,26 +50,23 @@ function InputTextForm({
   const handleSubmit = (e) => {
     e.preventDefault()
     if (isRequired(text)) {
-      action(text)
+      onSubmit(text)
     } else {
-      placeholder = '필수 입력값입니다.'
+      console.warn('답변이 비어있습니다')
     }
-    //action함수는 prop으로 전달받습니다. TextArea의 내용을 파라미터로 전달해 post/patch 할 수 있습니다.
+    //onSubmit함수는 prop으로 전달받습니다. onSubmit={(text) => {answerButtonOnClick(text)}}
+    //answerButtonOnClick 이 핸들러에서 text를 전달받아 사용할 수 있습니다.
   }
-  const buttonBackgroundColor = isRequired(text)
-    ? 'var(--brown40)'
-    : 'var(--brown30)'
+  const buttonColor = isRequired(text) ? 'var(--brown40)' : 'var(--brown30)'
 
   return (
     <StyledForm onSubmit={handleSubmit}>
       <TextArea
         onChange={handleInputChange}
         placeholder={placeholder}
+        value={text}
       ></TextArea>
-      <SendButton
-        type="submit"
-        style={{ backgroundColor: buttonBackgroundColor }}
-      >
+      <SendButton type="submit" style={{ backgroundColor: buttonColor }}>
         {buttonText}
       </SendButton>
     </StyledForm>

--- a/main/src/components/InputTextForm.jsx
+++ b/main/src/components/InputTextForm.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import styled from 'styled-components'
 import { isRequired } from '../utils/validationUtils'
-
+import media, { size } from '../utils/media'
 const StyledForm = styled.form`
   display: flex;
   flex-direction: column;
@@ -21,6 +21,8 @@ const TextArea = styled.textarea`
   &:focus {
     outline: 2px solid var(--brown40); /* 테두리 색상 변경 */
   }
+  ${media(size.tablet)`
+   font-size: 1.25rem `}
 `
 const SendButton = styled.button`
   width: 100%;

--- a/main/src/utils/getElapsedTime.js
+++ b/main/src/utils/getElapsedTime.js
@@ -17,10 +17,11 @@ function getElapsedTime(date) {
     // 한달 넘어가면 n달 전
     const monthsAgo = Math.floor(diff / (60 * 60 * 24 * 30))
     return `${monthsAgo}달 전`
-  } else {
+  } else if (diff >= 60 * 60 * 24 * 30 * 12) {
     // 1년 넘어가면 n년 전
     const yearsAgo = Math.floor(diff / (60 * 60 * 24 * 30 * 12))
     return `${yearsAgo}년 전`
-  }
+  } else return ''
+  // 예외처리
 }
 export default getElapsedTime


### PR DESCRIPTION
- 이제 페이지 상태, 답변상태, 수정중인 상태에 대해서 FeedCardAnswer가 조건부렌더링됩니다.
- InputTextForm에서 버튼동작을 기존에 action을 통해서 콜백을 받는 형태로 구현하려했으나 로직의 결점이 발견되어 새로운 로직으로 교체했습니다. 현재는 onSubmit을 prop으로 내려서 상위요소가 text를 전달받을 수 있게 구현했습니다. api동작은 상위요소에서 해주세요.
- 레이아웃 및 css는 figma 디자인 참고하여 적용하였습니다.
- FeedCard에서 렌더링된 수정하기와 답변하기 버튼을 누르면 해당 동작에 맞는 api함수가 호출됩니다. 현재 이 동작 이후에 FeedCard는 리렌더링되지 않습니다. 해당 사항 조치중에 있습니다.

![image](https://github.com/2team-project/OpenMind/assets/159979425/77ed5ce4-31d2-4fff-acdb-4f9eef0a5cb5)
