### PR TITLE
[feat] 일부 동작 시 리렌더링되는 기능 추가

### DIFF
--- a/main/src/components/Badge.jsx
+++ b/main/src/components/Badge.jsx
@@ -20,10 +20,10 @@ const StyledDiv = styled.div`
   ${getBadgeStyles}// 조건부 스타일을 적용하는 함수 호출
 `
 
-function Badge({ isAnswered = false }) {
+function Badge({ $isAnswered = false }) {
   return (
-    <StyledDiv isAnswered={isAnswered}>
-      {isAnswered ? '답변 완료' : '미답변'}
+    <StyledDiv $isAnswered={$isAnswered}>
+      {$isAnswered ? '답변 완료' : '미답변'}
     </StyledDiv>
   )
 }

--- a/main/src/components/FeedCard.jsx
+++ b/main/src/components/FeedCard.jsx
@@ -72,11 +72,15 @@ function FeedCard({ subject, question, setNeedRefresh }) {
 
   const handleReject = async () => {
     if (isAnswered) {
-      await updateAnswer(question.answer.id, '거절된 질문입니다', true)
-      await setNeedRefresh((prevValue) => prevValue + 1)
+      const answer = await updateAnswer(
+        question.answer.id,
+        '거절된 질문입니다',
+        true
+      )
+      setNeedRefresh(answer)
     } else {
-      await createAnswer(question.id, '거절된 질문입니다', true)
-      await setNeedRefresh((prevValue) => prevValue + 1)
+      const answer = await createAnswer(question.id, '거절된 질문입니다', true)
+      setNeedRefresh(answer)
     }
     console.log('거절 동작')
   }

--- a/main/src/components/FeedCard.jsx
+++ b/main/src/components/FeedCard.jsx
@@ -63,7 +63,7 @@ function FeedCard({ subject, question, setNeedRefresh }) {
     pageState()
   }, [location])
 
-  const isAnswered = question.answer !== null
+  const $isAnswered = question.answer !== null
 
   const handleEdit = () => {
     setEditing(true)
@@ -71,7 +71,7 @@ function FeedCard({ subject, question, setNeedRefresh }) {
   }
 
   const handleReject = async () => {
-    if (isAnswered) {
+    if ($isAnswered) {
       const answer = await updateAnswer(
         question.answer.id,
         '거절된 질문입니다',
@@ -88,7 +88,7 @@ function FeedCard({ subject, question, setNeedRefresh }) {
   return (
     <StyledDiv>
       <StyledMenubar>
-        <Badge isAnswered={isAnswered} />
+        <Badge $isAnswered={$isAnswered} />
         {isAnswerPage && (
           <DropdownForAnswer onEdit={handleEdit} onReject={handleReject} />
         )}

--- a/main/src/components/FeedCardAnswer.jsx
+++ b/main/src/components/FeedCardAnswer.jsx
@@ -119,15 +119,15 @@ function FeedCardAnswer({
   // 수정하기 버튼 동작
   const editButtonOnClick = async (content) => {
     console.log(content)
-    await updateAnswer(answer.id, content, false)
-    setNeedRefresh((prevValue) => prevValue + 1)
+    const $answer = await updateAnswer(answer.id, content, false)
+    setNeedRefresh($answer)
   }
 
   // 답변하기 버튼 동작
   const answerButtonOnClick = async (content) => {
     console.log(content)
-    await createAnswer(question.id, content, false)
-    setNeedRefresh((prevValue) => prevValue + 1)
+    const $answer = await createAnswer(question.id, content, false)
+    setNeedRefresh($answer)
   }
 
   // 답변을 한 경우

--- a/main/src/pages/answer/AnswerPage.jsx
+++ b/main/src/pages/answer/AnswerPage.jsx
@@ -5,7 +5,12 @@ import media, { size } from '../../utils/media'
 import ButtonShare from '../../components/ButtonShare'
 import DeleteAllButton from './DeleteAllButton'
 import { ReactComponent as MessagesIcon } from '../../../public/icons/messages.svg'
-import { getId, getQuestions, deleteQuestion } from '../../utils/apiUtils'
+import {
+  getId,
+  getQuestions,
+  deleteQuestion,
+  getQuestionDetails,
+} from '../../utils/apiUtils'
 import FeedCard from '../../components/FeedCard'
 
 const PageContainer = styled.div`
@@ -139,12 +144,10 @@ function AnswerPage() {
   const [error, setError] = useState(null)
   const [page, setPage] = useState(1) // 페이지 수
   const [totalQuestions, setTotalQuestions] = useState(0) // 전체 질문 개수
+  const [needRefresh, setNeedRefresh] = useState(null) //리렌더링 필요시 값을 변경시켜서 사용
 
   const observer = useRef(null)
   const lastQuestionElementRef = useRef(null)
-
-  //새로고침에 필요한 상태입니다. setNeedRefresh((prevValue) => prevValue + 1) 하여 사용하세요.
-  const [needRefresh, setNeedRefresh] = useState(1)
 
   useEffect(() => {
     async function loadSubject() {
@@ -161,6 +164,32 @@ function AnswerPage() {
       loadSubject()
     }
   }, [id])
+
+  //질문 새로고침 로직
+  useEffect(() => {
+    async function refreshQuestions() {
+      try {
+        setLoading(true)
+        const questionId = needRefresh.questionId
+        const refreshedQuestion = await getQuestionDetails(questionId)
+        const refreshedQuestions = questions.map((question) => {
+          if (question.id === questionId) {
+            return refreshedQuestion
+          }
+          return question
+        })
+        setQuestions([...refreshedQuestions])
+      } catch (err) {
+        console.err('새로고침 실패', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (needRefresh !== null) {
+      refreshQuestions()
+    }
+  }, [needRefresh])
 
   useEffect(() => {
     async function loadQuestions() {
@@ -211,16 +240,16 @@ function AnswerPage() {
   }, [loading, totalQuestions, questions.length])
 
   const handleDeleteAllQuestions = async () => {
-    Promise.all(questions.map(question => deleteQuestion(question.id)))
+    Promise.all(questions.map((question) => deleteQuestion(question.id)))
       .then(() => {
-        setQuestions([]);
-        alert('모든 질문을 삭제했습니다.');
+        setQuestions([])
+        alert('모든 질문을 삭제했습니다.')
       })
-      .catch(error => {
-        console.error('질문 삭제에 오류가 일어났습니다:', error);
-        alert('질문 삭제를 실패했습니다');
-      });
-  };
+      .catch((error) => {
+        console.error('질문 삭제에 오류가 일어났습니다:', error)
+        alert('질문 삭제를 실패했습니다')
+      })
+  }
 
   if (loading) return <p>Loading...</p>
   if (error) return <p>Error: {error}</p>
@@ -238,16 +267,16 @@ function AnswerPage() {
       </Header>
       <Body>
         <DeleteButtonContainer>
-          <DeleteAllButton onClick={handleDeleteAllQuestions}/>
+          <DeleteAllButton onClick={handleDeleteAllQuestions} />
         </DeleteButtonContainer>
         <QuestionsContainer>
           <QuestionCount>
             <MessageIcon />
-            {subject.questionCount}개의 질문이 있습니다.
+            {totalQuestions}개의 질문이 있습니다.
           </QuestionCount>
           {questions.length ? (
             questions.map((question, index) => {
-              const key = `${question.id}_${index}` // 고유한 키 생성 (안 하고 qusetion.id로 key 설정하면 로드될때 warning 겁나 뜸)
+              const key = `${question.id}__${index}` // 고유한 키 생성 (안 하고 qusetion.id로 key 설정하면 로드될때 warning 겁나 뜸)
               if (questions.length === index + 1) {
                 return (
                   <div ref={lastQuestionElementRef} key={key}>
@@ -255,6 +284,7 @@ function AnswerPage() {
                       key={question.id}
                       subject={subject}
                       question={question}
+                      setNeedRefresh={setNeedRefresh}
                     />
                   </div>
                 )
@@ -264,6 +294,7 @@ function AnswerPage() {
                     key={question.id}
                     subject={subject}
                     question={question}
+                    setNeedRefresh={setNeedRefresh}
                   />
                 )
               }

--- a/main/src/pages/post/PostPage.jsx
+++ b/main/src/pages/post/PostPage.jsx
@@ -185,7 +185,13 @@ function PostPage() {
       <StyledFloatingButtonWrapper onClick={switchModalOpen}>
         <ButtonFloating />
       </StyledFloatingButtonWrapper>
-      {isModalOpen && <Modal onClose={switchModalOpen} subject={subject} />}
+      {isModalOpen && (
+        <Modal
+          onClose={switchModalOpen}
+          subject={subject}
+          setNeedRefresh={setNeedRefresh}
+        />
+      )}
     </S.PageContainer>
   )
 }


### PR DESCRIPTION
Post페이지, Answer페이지에 해당합니다. 
Post페이지에서는 질문을 올리는 동작 시 전체 questions 배열을 다시 받아와 리렌더링합니다. 새로운 question이 생성되 첫번째로 배치되야하기 때문에 해당 방법을 취했습니다.

Answer페이지에서는 답변이 완료된 후 reponse로 오는 답변정보의 questionId를 통해 질문 하나의 정보만 다시 받아와 리렌더링을 시도했으나 정보는 다 받아놓고 정작 리렌더링이 발생하지는 않는 상태입니다. 현재는 loading state를 건드리는 부분을 추가해 동작을 구현했습니다.
현재 새로고침 후 스크롤이 위로 올라가버리는 문제는 아쉽게도 해결하지 못하였습니다.

![image](https://github.com/2team-project/OpenMind/assets/159979425/8ea7e195-2421-4c8d-aa8b-f2a2e90e7a0b)

추가로 어케 업데이트가 안된건지 $isAnswered가 isAnswered로 바뀌어있어서 다시 수정했습니다.

간단한 테스트로 answer과 post페이지에서 정상적으로 작동하는것으로 보입니다. 추가 버그 발견 등 이슈 발생하면 바로 말씀해주세요.

질문 삭제하기가 아직 완성 안된것으로 보입니다. 요구사항을 완전히 충족하기보다는 케밥버튼에 삭제하기버튼을 옮기는 등 가능한 부분으로 구현하는것도 좋은 방법이 될 것 같습니다.